### PR TITLE
fix: game subject from the game attribute

### DIFF
--- a/socket/roles/manager.js
+++ b/socket/roles/manager.js
@@ -49,7 +49,7 @@ const Manager = {
       name: "SHOW_START",
       data: {
         time: 3,
-        subject: "Adobe",
+        subject: game.subject,
       },
     })
 


### PR DESCRIPTION
The name Adobe was hardcoded, after the fix it takes from the game attributes