### PR TITLE
Added a reconnecting feature which restores your points and rankings

### DIFF
--- a/socket/roles/player.js
+++ b/socket/roles/player.js
@@ -2,19 +2,22 @@ import convertTimeToPoint from "../utils/convertTimeToPoint.js"
 import { abortCooldown } from "../utils/cooldown.js"
 import { inviteCodeValidator, usernameValidator } from "../validator.js"
 
+import {
+  deleteDisconnectedPlayer, //importing the new module for disconnected players
+  getDisconnectedPlayer,
+} from "../utils/disconnectedStore.js"
+
 const Player = {
   checkRoom: async (game, io, socket, roomId) => {
     try {
       await inviteCodeValidator.validate(roomId)
     } catch (error) {
       socket.emit("game:errorMessage", error.errors[0])
-
       return
     }
 
     if (!game.room || roomId !== game.room) {
       socket.emit("game:errorMessage", "Room not found")
-
       return
     }
 
@@ -26,25 +29,39 @@ const Player = {
       await usernameValidator.validate(player.username)
     } catch (error) {
       socket.emit("game:errorMessage", error.errors[0])
-
       return
     }
 
     if (!game.room || player.room !== game.room) {
       socket.emit("game:errorMessage", "Room not found")
-
       return
     }
+//checking if player existed previously (either by sessionToken or username)
+    const existingByToken = player.sessionToken
+      ? game.players.find((p) => p.sessionToken === player.sessionToken)
+      : null
+    const existingByUsername = game.players.find(
+      (p) => p.username === player.username,
+    )
 
-    if (game.players.find((p) => p.username === player.username)) {
-      socket.emit("game:errorMessage", "Username already exists")
-
+//if client provides a token or same username exists, allow reattach even if started
+    if (existingByToken || existingByUsername) {
+      const existing = existingByToken || existingByUsername
+      socket.join(game.room)
+      existing.id = socket.id
+      if (player.sessionToken) existing.sessionToken = player.sessionToken
+      socket.emit("game:rejoinSuccess", {
+        username: existing.username,
+        room: existing.room,
+        points: existing.points,
+      })
+      io.to(game.manager).emit("manager:playerRejoined", existing.id)
+      io.to(game.room).emit("game:totalPlayers", game.players.length)
       return
     }
 
     if (game.started) {
       socket.emit("game:errorMessage", "Game already started")
-
       return
     }
 
@@ -52,25 +69,83 @@ const Player = {
 
     socket.join(player.room)
 
-    const playerData = {
+    const sessionToken = `${player.room}_${socket.id}_${Date.now()}` //create a session token tied to room and current socket id
+
+    let playerData = {
       username: player.username,
       room: player.room,
       id: socket.id,
       points: 0,
+      sessionToken, //extra field for sessionToken
     }
     socket.to(player.room).emit("manager:newPlayer", { ...playerData })
 
     game.players.push(playerData)
 
-    // Emit total players to all players in the room
-    io.to(player.room).emit("game:totalPlayers", game.players.length)
+    io.to(player.room).emit("game:totalPlayers", game.players.length) //emit total players to all players in the room
 
-    socket.emit("game:successJoin")
+    socket.emit("game:successJoin", { sessionToken })
+  },
+
+  //new function for rejoining
+  rejoin: (game, io, socket, { sessionToken }) => {
+    if (!sessionToken) {
+      socket.emit("game:errorMessage", "Missing session token")
+      return
+    }
+
+    const saved = getDisconnectedPlayer(sessionToken)
+    if (!saved) {
+      socket.emit("game:errorMessage", "Rejoin session expired or invalid")
+      return
+    }
+
+    if (!game.room || saved.roomId !== game.room) {
+      socket.emit("game:errorMessage", "Room not found")
+      deleteDisconnectedPlayer(sessionToken)
+      return
+    }
+
+    if (Date.now() > saved.expiresAt) {
+      deleteDisconnectedPlayer(sessionToken)
+      socket.emit("game:errorMessage", "Rejoin window expired")
+      return
+    }
+
+    //find existing player by prior id or username and update socket id
+    const existing =
+      game.players.find((p) => p.sessionToken === sessionToken) ||
+      game.players.find((p) => p.username === saved.username)
+
+    if (!existing) {
+      //if not found, deny rejoin
+      deleteDisconnectedPlayer(sessionToken)
+      socket.emit("game:errorMessage", "Player not found in game")
+      return
+    }
+
+    //move socket into room and update references
+    socket.join(saved.roomId)
+    existing.id = socket.id
+    existing.sessionToken = sessionToken
+    existing.points = saved.points || existing.points || 0
+
+    //notify player success and manager of rejoin
+    socket.emit("game:rejoinSuccess", {
+      username: existing.username,
+      room: existing.room,
+      points: existing.points,
+    })
+    io.to(game.manager).emit("manager:playerRejoined", existing.id)
+
+    deleteDisconnectedPlayer(sessionToken)
+
+    //optionally sync counts
+    io.to(game.room).emit("game:totalPlayers", game.players.length)
   },
 
   selectedAnswer: (game, io, socket, answerKey) => {
     const player = game.players.find((player) => player.id === socket.id)
-
     const question = game.questions[game.currentQuestion]
 
     if (!player) {

--- a/socket/utils/disconnectedStore.js
+++ b/socket/utils/disconnectedStore.js
@@ -1,0 +1,29 @@
+//logic for temporarily disconnected players
+
+const disconnectedPlayers = new Map() //gonna store the player data as key value pairs (key is sessionToken and value is player data)
+
+export function saveDisconnectedPlayer(sessionToken, data) {
+  disconnectedPlayers.set(sessionToken, data)
+}
+
+export function getDisconnectedPlayer(sessionToken) {
+  return disconnectedPlayers.get(sessionToken)
+}
+
+export function deleteDisconnectedPlayer(sessionToken) {
+  disconnectedPlayers.delete(sessionToken)
+}
+
+//delete the player data if the player takes too long to rejoin
+export function sweepExpiredDisconnectedPlayers() {
+  const now = Date.now()
+  for (const [token, data] of disconnectedPlayers.entries()) {
+    if (!data || typeof data.expiresAt !== "number" || now > data.expiresAt) {
+      disconnectedPlayers.delete(token)
+    }
+  }
+}
+
+export default disconnectedPlayers
+
+

--- a/src/context/socket.jsx
+++ b/src/context/socket.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react"
+import { createContext, useContext, useEffect } from "react"
 import { io } from "socket.io-client"
 import { WEBSOCKET_PUBLIC_URL } from "../../config.mjs"
 
@@ -8,9 +8,50 @@ export const socket = io(WEBSOCKET_PUBLIC_URL, {
 
 export const SocketContext = createContext()
 
-export const SocketContextProvider = ({ children }) => (
-  <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>
-)
+//exponential backoff for rejoining
+export const SocketContextProvider = ({ children }) => {
+  useEffect(() => {
+    let attempt = 0
+    let timeoutId
+
+    const tryRejoin = () => {
+      let token
+      try {
+        token = localStorage.getItem("rahoot_sessionToken")
+      } catch {}
+
+      if (!token) return
+
+      socket.emit("player:rejoin", { sessionToken: token })
+      attempt++
+      const delay = Math.min(30000, 1000 * Math.pow(2, attempt)) //1,2,4,8... max 30s
+      timeoutId = setTimeout(tryRejoin, delay)
+    }
+
+    const onConnect = () => {
+      attempt = 0
+      tryRejoin()
+    }
+
+    const onRejoinSuccess = () => {
+      if (timeoutId) clearTimeout(timeoutId)
+      attempt = 0
+    }
+
+    socket.on("connect", onConnect)
+    socket.on("game:rejoinSuccess", onRejoinSuccess)
+
+    return () => {
+      socket.off("connect", onConnect)
+      socket.off("game:rejoinSuccess", onRejoinSuccess)
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [])
+
+  return (
+    <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>
+  )
+}
 
 export function useSocketContext() {
   const context = useContext(SocketContext)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,22 +4,33 @@ import Username from "@/components/game/join/Username"
 import { usePlayerContext } from "@/context/player"
 import { useSocketContext } from "@/context/socket"
 import Image from "next/image"
+import { useRouter } from "next/router"
 import { useEffect } from "react"
 import toast from "react-hot-toast"
 
 export default function Home() {
-  const { player } = usePlayerContext()
+  const { player, dispatch } = usePlayerContext()
   const { socket } = useSocketContext()
+  const router = useRouter()
 
   useEffect(() => {
     socket.on("game:errorMessage", (message) => {
       toast.error(message)
     })
+//rejoining
+    const onRejoinSuccess = ({ username, room }) => {
+      dispatch({ type: "JOIN", payload: room })
+      dispatch({ type: "LOGIN", payload: username })
+      router.replace("/game")
+    }
+
+    socket.on("game:rejoinSuccess", onRejoinSuccess)
 
     return () => {
       socket.off("game:errorMessage")
+      socket.off("game:rejoinSuccess", onRejoinSuccess)
     }
-  }, [socket])
+  }, [])
 
   return (
     <section className="relative flex min-h-screen flex-col items-center justify-center">


### PR DESCRIPTION
Hey, I had cloned this repo for an event that we wanted to host on our campus. Internet issues are common here so I decided to implement a reconnecting feature.
This pull request introduces a reconnection and session restoration system for players. If someone disconnects due to wifi issues or accidental refreshes, they can now automatically rejoin the game without losing points or leaderboard rankings.

* temporary store for disconnected players via a map keyed by sessionToken
* server clears/sweeps disconnected entries every 5 minutes (players must rejoin within those 5 mins)
* player:rejoin event handles the process
* exponential backoff on socket.connect() [max 30s]

files changed -> **~/socket/roles/player.js, ~/socket/index.js, ~/src/pages/index.js, ~/socket/utils/disconnectedStore.js, Username.jsx and socket.jsx**