### PR TITLE
Add video & audio question types (media embedded in answers)

### DIFF
--- a/config/quizz/example.json
+++ b/config/quizz/example.json
@@ -23,6 +23,22 @@
       "solution": 0,
       "cooldown": 5,
       "time": 20
+    },
+    {
+      "question": "What is good answer with video ?",
+      "answers": ["Good answer", "No", "No", "No"],
+      "video": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+      "solution": 0,
+      "cooldown": 5,
+      "time": 10
+    },
+    {
+      "question": "What is good answer with audio ?",
+      "answers": ["No", "No", "Good answer", "No"],
+      "audio": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+      "solution": 2,
+      "cooldown": 5,
+      "time": 15
     }
   ]
 }

--- a/packages/common/src/types/game/index.ts
+++ b/packages/common/src/types/game/index.ts
@@ -17,6 +17,8 @@ export type Quizz = {
   questions: {
     question: string
     image?: string
+    video?: string
+    audio?: string
     answers: string[]
     solution: number
     cooldown: number

--- a/packages/common/src/types/game/status.ts
+++ b/packages/common/src/types/game/status.ts
@@ -23,6 +23,8 @@ export type CommonStatusDataMap = {
     question: string
     answers: string[]
     image?: string
+    video?: string
+    audio?: string
     time: number
     totalPlayer: number
   }
@@ -46,6 +48,7 @@ type ManagerExtraStatus = {
     correct: number
     answers: string[]
     image?: string
+    video?: string
   }
   SHOW_LEADERBOARD: { oldLeaderboard: Player[]; leaderboard: Player[] }
 }

--- a/packages/socket/src/services/game.ts
+++ b/packages/socket/src/services/game.ts
@@ -361,6 +361,8 @@ class Game {
       question: question.question,
       answers: question.answers,
       image: question.image,
+      video: question.video,
+      audio: question.audio,
       time: question.time,
       totalPlayer: this.players.length,
     })

--- a/packages/web/src/components/game/states/Answers.tsx
+++ b/packages/web/src/components/game/states/Answers.tsx
@@ -20,7 +20,7 @@ type Props = {
 }
 
 const Answers = ({
-  data: { question, answers, image, time, totalPlayer },
+  data: { question, answers, image, audio, video, time, totalPlayer },
 }: Props) => {
   const { gameId }: { gameId?: string } = useParams()
   const { socket } = useSocket()
@@ -54,6 +54,10 @@ const Answers = ({
   }
 
   useEffect(() => {
+    if (video || audio) {
+      return
+    }
+    
     playMusic()
 
     return () => {
@@ -76,6 +80,24 @@ const Answers = ({
         <h2 className="text-center text-2xl font-bold text-white drop-shadow-lg md:text-4xl lg:text-5xl">
           {question}
         </h2>
+
+        {(Boolean(audio) && !player) && (
+          <audio
+            className="m-4 max-h-[400px] w-auto rounded-md"
+            src={audio}
+            autoPlay
+            controls
+          />
+        )}
+
+        {(Boolean(video) && !player) && (
+          <video
+            className="aspect-video bg-black m-4 h-full max-h-[400px] min-h-[200px] w-auto rounded-md"
+            src={video}
+            autoPlay
+            controls
+          />
+        )}
 
         {Boolean(image) && (
           <img


### PR DESCRIPTION
Hi,

First off, thank you for creating this project 😊.

I’ve added new question types that let media (video & audio) be embedded directly into quizzes.

Media elements are rendered inside the `<Answers />` component.
Because of component‑state changes, I didn’t place the media elements in the `<Question />` component.
For loading considerations, the media are not displayed on the players screens.

Please review the changes and let me know if anything needs adjustment. I’m happy to make edits based on your feedback.

Thanks