### PR TITLE
feat/auth-page-reconnect

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -20,6 +20,8 @@ export const EVENTS = {
     RECONNECT: "player:reconnect",
     LEAVE: "player:leave",
     SELECTED_ANSWER: "player:selectedAnswer",
+    CHECK_PIN: "player:checkPin",
+    CHECK_PIN_RESULT: "player:checkPinResult",
   },
   MANAGER: {
     SUCCESS_RECONNECT: "manager:successReconnect",

--- a/packages/common/src/types/game/socket.ts
+++ b/packages/common/src/types/game/socket.ts
@@ -50,6 +50,7 @@ export interface ServerToClientEvents {
   [EVENTS.GAME.PLAYER_ANSWER]: (_count: number) => void
 
   // Player events
+  [EVENTS.PLAYER.CHECK_PIN_RESULT]: (_data: { valid: boolean }) => void
   [EVENTS.PLAYER.SUCCESS_RECONNECT]: (_data: {
     gameId: string
     status: { name: Status; data: StatusDataMap[Status] }
@@ -114,6 +115,7 @@ export interface ClientToServerEvents {
   [EVENTS.QUIZZ.DELETE]: (_id: string) => void
 
   // Player actions
+  [EVENTS.PLAYER.CHECK_PIN]: (_inviteCode: string) => void
   [EVENTS.PLAYER.JOIN]: (_inviteCode: string) => void
   [EVENTS.PLAYER.LOGIN]: (
     _message: MessageWithoutStatus<{ username: string }>,

--- a/packages/socket/src/handlers/game.ts
+++ b/packages/socket/src/handlers/game.ts
@@ -77,6 +77,12 @@ export const gameSocketHandlers = ({ io, socket }: SocketContext) => {
     registry.addGame(game)
   })
 
+  socket.on(EVENTS.PLAYER.CHECK_PIN, (inviteCode) => {
+    const game = registry.getGameByInviteCode(inviteCode)
+
+    socket.emit(EVENTS.PLAYER.CHECK_PIN_RESULT, { valid: Boolean(game) })
+  })
+
   socket.on(EVENTS.PLAYER.JOIN, (inviteCode) => {
     const result = inviteCodeValidator.safeParse(inviteCode)
 
@@ -90,6 +96,18 @@ export const gameSocketHandlers = ({ io, socket }: SocketContext) => {
 
     if (!game) {
       socket.emit(EVENTS.GAME.ERROR_MESSAGE, "errors:game.notFound")
+
+      return
+    }
+
+    if (game.manager.clientId === clientId) {
+      socket.emit(EVENTS.GAME.ERROR_MESSAGE, "errors:game.managerCannotJoin")
+
+      return
+    }
+
+    if (game.players.some((p) => p.clientId === clientId)) {
+      game.reconnect(socket)
 
       return
     }

--- a/packages/web/src/features/game/components/join/Reconnect.tsx
+++ b/packages/web/src/features/game/components/join/Reconnect.tsx
@@ -1,0 +1,92 @@
+import { EVENTS } from "@razzia/common/constants"
+import Button from "@razzia/web/components/Button"
+import Card from "@razzia/web/components/Card"
+import {
+  useEvent,
+  useSocket,
+} from "@razzia/web/features/game/contexts/socket-context"
+import { usePlayerStore } from "@razzia/web/features/game/stores/player"
+import { useQuestionStore } from "@razzia/web/features/game/stores/question"
+import { useNavigate } from "@tanstack/react-router"
+import { X } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import toast from "react-hot-toast"
+import { useTranslation } from "react-i18next"
+
+const Reconnect = () => {
+  const { isConnected, socket } = useSocket()
+  const { setGameId, setPlayer, setStatus } = usePlayerStore()
+  const { setQuestionStates } = useQuestionStore()
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+  const [savedPin, setSavedPin] = useState(() =>
+    localStorage.getItem("game_pin"),
+  )
+  const [isChecking, setIsChecking] = useState(
+    Boolean(localStorage.getItem("game_pin")),
+  )
+  const hasCheckedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isConnected || hasCheckedRef.current || !savedPin) {
+      return
+    }
+
+    hasCheckedRef.current = true
+    socket.emit(EVENTS.PLAYER.CHECK_PIN, savedPin)
+  }, [isConnected, savedPin, socket])
+
+  useEvent(EVENTS.PLAYER.CHECK_PIN_RESULT, ({ valid }) => {
+    setIsChecking(false)
+
+    if (!valid) {
+      localStorage.removeItem("game_pin")
+      setSavedPin(null)
+    }
+  })
+
+  const handleReconnect = () => {
+    if (savedPin) {
+      socket.emit(EVENTS.PLAYER.JOIN, savedPin)
+    }
+  }
+
+  const handleDismiss = () => {
+    localStorage.removeItem("game_pin")
+    setSavedPin(null)
+  }
+
+  useEvent(EVENTS.GAME.RESET, (message) => {
+    toast.error(t(message))
+  })
+
+  useEvent(
+    EVENTS.PLAYER.SUCCESS_RECONNECT,
+    ({ gameId, status, player, currentQuestion }) => {
+      setGameId(gameId)
+      setStatus(status.name, status.data)
+      setPlayer(player)
+      setQuestionStates(currentQuestion)
+      navigate({ to: "/party/$gameId", params: { gameId } })
+    },
+  )
+
+  if (!savedPin || isChecking) {
+    return null
+  }
+
+  return (
+    <Card className="relative mt-4 gap-3">
+      <button
+        className="absolute top-3 right-3 opacity-40 hover:opacity-100"
+        onClick={handleDismiss}
+      >
+        <X className="size-6" />
+      </button>
+      <p className="font-semibold">{t("game:reconnectTitle")}</p>
+      <Button onClick={handleReconnect}>{t("game:reconnect")}</Button>
+    </Card>
+  )
+}
+
+export default Reconnect

--- a/packages/web/src/features/game/components/join/Room.tsx
+++ b/packages/web/src/features/game/components/join/Room.tsx
@@ -24,6 +24,12 @@ const Room = () => {
   }
 
   useEvent(EVENTS.GAME.SUCCESS_ROOM, (gameId) => {
+    const pinToSave = invitation.replace(/\s/gu, "") || pin
+
+    if (pinToSave) {
+      localStorage.setItem("game_pin", pinToSave)
+    }
+
     join(gameId)
   })
 

--- a/packages/web/src/locales/de/errors.json
+++ b/packages/web/src/locales/de/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "Manager bereits verbunden",
     "managerDisconnected": "Manager getrennt",
     "noPlayersConnected": "Keine Spieler verbunden",
+    "managerCannotJoin": "Du kannst deinem eigenen Spiel nicht beitreten",
     "notFound": "Spiel nicht gefunden",
     "playerAlreadyConnected": "Spieler bereits verbunden"
   },

--- a/packages/web/src/locales/de/game.json
+++ b/packages/web/src/locales/de/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "Tritt dem Spiel bei auf",
   "leaderboard": "Bestenliste",
   "pinLabel": "PIN-Code",
+  "reconnect": "Erneut verbinden",
+  "reconnectTitle": "Du warst in einem Spiel",
   "playersJoined": "Verbundene Spieler: ",
   "questionPrefix": "Frage #",
   "rank": {

--- a/packages/web/src/locales/en/errors.json
+++ b/packages/web/src/locales/en/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "Manager already connected",
     "managerDisconnected": "Manager disconnected",
     "noPlayersConnected": "No players connected",
+    "managerCannotJoin": "You cannot join your own game",
     "notFound": "Game not found",
     "playerAlreadyConnected": "Player already connected"
   },

--- a/packages/web/src/locales/en/game.json
+++ b/packages/web/src/locales/en/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "Join the game at",
   "leaderboard": "Leaderboard",
   "pinLabel": "PIN Code",
+  "reconnect": "Reconnect",
+  "reconnectTitle": "You were in a game",
   "playersJoined": "Players Joined: ",
   "questionPrefix": "Question #",
   "rank": {

--- a/packages/web/src/locales/es/errors.json
+++ b/packages/web/src/locales/es/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "El administrador ya está conectado",
     "managerDisconnected": "El administrador se ha desconectado",
     "noPlayersConnected": "No hay jugadores conectados",
+    "managerCannotJoin": "No puedes unirte a tu propio juego",
     "notFound": "Partida no encontrada",
     "playerAlreadyConnected": "El jugador ya está conectado"
   },

--- a/packages/web/src/locales/es/game.json
+++ b/packages/web/src/locales/es/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "Únete al juego en",
   "leaderboard": "Clasificación",
   "pinLabel": "Código PIN",
+  "reconnect": "Reconectar",
+  "reconnectTitle": "Estabas en una partida",
   "playersJoined": "Jugadores conectados: ",
   "questionPrefix": "Pregunta #",
   "rank": {

--- a/packages/web/src/locales/fr/errors.json
+++ b/packages/web/src/locales/fr/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "Un manager est déjà connecté",
     "managerDisconnected": "Le manager s'est déconnecté",
     "noPlayersConnected": "Aucun joueur connecté",
+    "managerCannotJoin": "Vous ne pouvez pas rejoindre votre propre partie",
     "notFound": "Partie introuvable",
     "playerAlreadyConnected": "Ce joueur est déjà connecté"
   },

--- a/packages/web/src/locales/fr/game.json
+++ b/packages/web/src/locales/fr/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "Rejoins la partie sur",
   "leaderboard": "Classement",
   "pinLabel": "Code PIN",
+  "reconnect": "Reconnecter",
+  "reconnectTitle": "Vous étiez dans une partie",
   "playersJoined": "Joueurs connectés : ",
   "questionPrefix": "Question n°",
   "rank": {

--- a/packages/web/src/locales/it/errors.json
+++ b/packages/web/src/locales/it/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "Gestore già connesso",
     "managerDisconnected": "Gestore disconnesso",
     "noPlayersConnected": "Nessun giocatore connesso",
+    "managerCannotJoin": "Non puoi unirti alla tua stessa partita",
     "notFound": "Partita non trovata",
     "playerAlreadyConnected": "Giocatore già connesso"
   },

--- a/packages/web/src/locales/it/game.json
+++ b/packages/web/src/locales/it/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "Unisciti al gioco su",
   "leaderboard": "Classifica",
   "pinLabel": "Codice PIN",
+  "reconnect": "Riconnetti",
+  "reconnectTitle": "Eri in una partita",
   "playersJoined": "Giocatori connessi: ",
   "questionPrefix": "Domanda #",
   "rank": {

--- a/packages/web/src/locales/ja/errors.json
+++ b/packages/web/src/locales/ja/errors.json
@@ -10,6 +10,7 @@
     "managerAlreadyConnected": "管理者はすでに接続されています",
     "managerDisconnected": "管理者が切断されました",
     "noPlayersConnected": "接続中のプレイヤーがいません",
+    "managerCannotJoin": "自分のゲームには参加できません",
     "notFound": "ゲームが見つかりません",
     "playerAlreadyConnected": "プレイヤーはすでに接続されています"
   },

--- a/packages/web/src/locales/ja/game.json
+++ b/packages/web/src/locales/ja/game.json
@@ -8,6 +8,8 @@
   "joinInstruction": "以下でゲームに参加してください",
   "leaderboard": "リーダーボード",
   "pinLabel": "PINコード",
+  "reconnect": "再接続",
+  "reconnectTitle": "ゲームに参加していました",
   "playersJoined": "参加プレイヤー数: ",
   "questionPrefix": "問題 #",
   "rank": {

--- a/packages/web/src/pages/(auth)/index.tsx
+++ b/packages/web/src/pages/(auth)/index.tsx
@@ -1,3 +1,4 @@
+import Reconnect from "@razzia/web/features/game/components/join/Reconnect"
 import Room from "@razzia/web/features/game/components/join/Room"
 import Username from "@razzia/web/features/game/components/join/Username"
 import {
@@ -29,7 +30,12 @@ const PlayerAuthPage = () => {
     return <Username />
   }
 
-  return <Room />
+  return (
+    <>
+      <Room />
+      <Reconnect />
+    </>
+  )
 }
 
 export const Route = createFileRoute("/(auth)/")({

--- a/packages/web/src/pages/party/$gameId.tsx
+++ b/packages/web/src/pages/party/$gameId.tsx
@@ -51,6 +51,7 @@ const PlayerGamePage = () => {
   })
 
   useEvent(EVENTS.GAME.RESET, (message) => {
+    localStorage.removeItem("game_pin")
     navigate({ to: "/" })
     reset()
     setQuestionStates(null)


### PR DESCRIPTION
## Add player reconnection from auth page

### What it does

When a player joins a game, the PIN is saved to `localStorage`.

If they lose the party URL and go back to the auth page, a **reconnect card** automatically appears below the PIN input. One click on **Reconnect** brings them straight back into the game at the exact state they left (current question, score, etc.).

If the game has ended in the meantime, the card silently disappears with no error shown.

<img width="470" height="480" alt="reconnect-card" src="https://github.com/user-attachments/assets/01d42931-f8e2-4e9e-be48-42084264d787" />